### PR TITLE
[LEAS-1] add support for setting expirations for envelope creation

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -894,7 +894,14 @@ module DocusignRest
         eventNotification:  get_event_notification(options[:event_notification]),
         templateRoles:      get_template_roles(options[:signers]),
         customFields:       options[:custom_fields],
-        allowReassign:      options[:allow_reassign]
+        allowReassign:      options[:allow_reassign],
+        notification: {
+          expirations: {
+            expireAfter:      options[:expire_after].to_s,
+            expireEnabled:    options[:expire_enabled].to_s,
+            expireWarn:       options[:expire_warn].to_s
+          }
+        }
       }.to_json
 
       uri = build_uri("/accounts/#{acct_id}/envelopes")


### PR DESCRIPTION
# Context

As a leasing ops manager, I want leases in Docusign to automatically be set to expire in 999 days from the day of creation, so that I don't find accidentally-expired leases before we can have all tenants sign them.

This gives the ability for the `docusign_rest` client to control expiration dates. Paired with https://github.com/HiCommon/cmn-admin/pull/2192, this will extend envelope expiration dates to 999 days.

# Related Tickets

https://hicommon.atlassian.net/browse/LEAS-1

# Inside this PR

* A modification to  the `docusign_rest` client that converts expiry options into the post body

# How to test

1. First ensure that https://github.com/HiCommon/cmn-admin/pull/2192 is merged.
2. Create a new docusign envelope like so:
```
template_id = 'dfb002a0-48dc-4bbd-a416-b5b8dd3c7ac1'
DocusignEnvelope.create_from_template(template_id)
```
3. Log into docusign, find the sent envelope, click on the "i" icon on the top right, and ensure that the expiration date is set 999 days in the future.
4. Verify that the warning date is set to 30 days by clicking the "Correct" button and scrolling all the way down to the "advanced setting" section.